### PR TITLE
Add docblocks, add scripts, add void and refund methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 composer.lock
 composer.phar
 phpunit.xml
+.directory
+.idea
+dirlist.app
+dirlist.cache
+dirlist.vendor
+/documents

--- a/makedoc.sh
+++ b/makedoc.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+
+#
+# Smart little documentation generator.
+# GPL/LGPL
+# (c) Del 2015 http://www.babel.com.au/
+#
+
+APPNAME='Omnipay Manual Gateway Module'
+CMDFILE=apigen.cmd.$$
+DESTDIR=./documents
+
+#
+# Find apigen, either in the path or as a local phar file
+#
+if [ -f apigen.phar ]; then
+    APIGEN="php apigen.phar"
+
+else
+    APIGEN=`which apigen`
+    if [ ! -f "$APIGEN" ]; then
+        
+        # Search for phpdoc if apigen is not found.
+        if [ -f phpDocumentor.phar ]; then
+            PHPDOC="php phpDocumentor.phar"
+        
+        else
+            PHPDOC=`which phpdoc`
+            if [ ! -f "$PHPDOC" ]; then
+                echo "Neither apigen nor phpdoc is installed in the path or locally, please install one of them"
+                echo "see http://www.apigen.org/ or http://www.phpdoc.org/"
+                exit 1
+            fi
+        fi
+    fi
+fi
+
+#
+# As of version 4 of apigen need to use the generate subcommand
+#
+if [ ! -z "$APIGEN" ]; then
+    APIGEN="$APIGEN generate"
+fi
+
+#
+# Without any arguments this builds the entire system documentation,
+# making the cache file first if required.
+#
+if [ -z "$1" ]; then
+    #
+    # Check to see that the cache has been made.
+    #
+    if [ ! -f dirlist.cache ]; then
+        echo "Making dirlist.cache file"
+        $0 makecache
+    fi
+
+    #
+    # Build the apigen/phpdoc command in a file.
+    #
+    if [ ! -z "$APIGEN" ]; then
+        echo "$APIGEN --php --tree --title '$APPNAME API Documentation' --destination $DESTDIR/main \\" > $CMDFILE
+        cat dirlist.cache | while read dir; do
+            echo "--source $dir \\" >> $CMDFILE
+        done
+        echo "" >> $CMDFILE
+    
+    elif [ ! -z "$PHPDOC" ]; then
+        echo "$PHPDOC --sourcecode --title '$APPNAME API Documentation' --target $DESTDIR/main --directory \\" > $CMDFILE
+        cat dirlist.cache | while read dir; do
+            echo "${dir},\\" >> $CMDFILE
+        done
+        echo "" >> $CMDFILE
+    
+    else
+        "Neither apigen nor phpdoc are found, how did I get here?"
+        exit 1
+    fi
+
+    #
+    # Run the apigen command
+    #
+    rm -rf $DESTDIR/main
+    mkdir -p $DESTDIR/main
+    . ./$CMDFILE
+    
+    /bin/rm -f ./$CMDFILE
+
+#
+# The "makecache" argument causes the script to just make the cache file
+#
+elif [ "$1" = "makecache" ]; then
+    echo "Find application source directories"
+    find src -name \*.php -print | \
+        (
+            while read file; do
+                grep -q 'class' $file && dirname $file
+            done
+        ) | sort -u | \
+        grep -v -E 'config|docs|migrations|phpunit|test|Test|views|web' > dirlist.app
+
+    echo "Find vendor source directories"
+    find vendor -name \*.php -print | \
+        (
+            while read file; do
+                grep -q 'class' $file && dirname $file
+            done
+        ) | sort -u | \
+        grep -v -E 'config|docs|migrations|phpunit|codesniffer|test|Test|views' > dirlist.vendor
+  
+    #
+    # Filter out any vendor directories for which apigen fails
+    #
+    echo "Filter source directories"
+    mkdir -p $DESTDIR/tmp
+    cat dirlist.app dirlist.vendor | while read dir; do
+        if [ ! -z "$APIGEN" ]; then
+            $APIGEN --quiet --title "Test please ignore" \
+                --source $dir \
+                --destination $DESTDIR/tmp && (
+                    echo "Including $dir"
+                    echo $dir >> dirlist.cache
+                ) || (
+                    echo "Excluding $dir"
+                )
+        
+        elif [ ! -z "$PHPDOC" ]; then
+            $PHPDOC --quiet --title "Test please ignore" \
+                --directory $dir \
+                --target $DESTDIR/tmp && (
+                    echo "Including $dir"
+                    echo $dir >> dirlist.cache
+                ) || (
+                    echo "Excluding $dir"
+                )
+
+        fi
+    done
+    echo "Documentation cache dirlist.cache built OK"
+    
+    #
+    # Clean up
+    #
+    /bin/rm -rf $DESTDIR/tmp
+
+fi

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+#
+# Command line runner for unit tests for composer projects
+# (c) Del 2015 http://www.babel.com.au/
+# No Rights Reserved
+#
+
+#
+# Clean up after any previous test runs
+#
+mkdir -p documents
+rm -rf documents/coverage-html-new
+rm -f documents/coverage.xml
+
+#
+# Run phpunit
+#
+vendor/bin/phpunit --coverage-html documents/coverage-html-new --coverage-clover documents/coverage.xml
+
+if [ -d documents/coverage-html-new ]; then
+  rm -rf documents/coverage-html
+  mv documents/coverage-html-new documents/coverage-html
+fi
+

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Manual Gateway
+ */
 
 namespace Omnipay\Manual;
 
@@ -9,6 +12,49 @@ use Omnipay\Common\AbstractGateway;
  *
  * This gateway is useful for processing check or direct debit payments. It simply
  * authorizes every payment.
+ *
+ * ### Example
+ *
+ * #### Initialize Gateway
+ *
+ * ```php
+ * // Create a gateway for the Manual Gateway
+ * // (routes to GatewayFactory::create)
+ * $gateway = Omnipay::create('Manual');
+ *
+ * // Initialise the gateway
+ * $gateway->initialize(array(
+ *     'testMode' => true, // Or false. Doesn't matter.
+ * ));
+ * ```
+ *
+ * #### Authorize
+ *
+ * <code>
+ * // Do a purchase transaction on the gateway
+ * try {
+ *     $transaction = $gateway->authorize(array(
+ *         'amount'        => '10.00',
+ *         'currency'      => 'AUD',
+ *         'description'   => 'This is a test transaction.',
+ *       ));
+ *     $response = $transaction->send();
+ *     $data = $response->getData();
+ *     echo "Gateway authorize response data == " . print_r($data, true) . "\n";
+ *
+ *     if ($response->isSuccessful()) {
+ *         echo "Transaction was successful!\n";
+ *     }
+ * } catch (\Exception $e) {
+ *     echo "Exception caught while attempting authorize.\n";
+ *     echo "Exception type == " . get_class($e) . "\n";
+ *     echo "Message == " . $e->getMessage() . "\n";
+ * }
+ * </code>
+ *
+ * In reality, Manual Gateway authorize() requests will always be successful and
+ * will never throw an exception, but the above example shows that you can treat
+ * manual payments just like any other payment type for any other gateway.
  */
 class Gateway extends AbstractGateway
 {
@@ -28,6 +74,16 @@ class Gateway extends AbstractGateway
     }
 
     public function capture(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Manual\Message\Request', $parameters);
+    }
+
+    public function void(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Manual\Message\Request', $parameters);
+    }
+
+    public function refund(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Manual\Message\Request', $parameters);
     }

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -1,11 +1,14 @@
 <?php
+/**
+ * Manual Gateway Request
+ */
 
 namespace Omnipay\Manual\Message;
 
 use Omnipay\Common\Message\AbstractRequest;
 
 /**
- * Manual Request
+ * Manual Gateway Request
  */
 class Request extends AbstractRequest
 {

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -1,11 +1,14 @@
 <?php
+/**
+ * Manual Gateway Response
+ */
 
 namespace Omnipay\Manual\Message;
 
 use Omnipay\Common\Message\AbstractResponse;
 
 /**
- * Manual Response
+ * Manual Gateway Response
  */
 class Response extends AbstractResponse
 {

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -38,4 +38,26 @@ class GatewayTest extends GatewayTestCase
         $this->assertNull($response->getTransactionReference());
         $this->assertNull($response->getMessage());
     }
+
+    public function testVoid()
+    {
+        $response = $this->gateway->void($this->options)->send();
+
+        $this->assertInstanceOf('\Omnipay\Manual\Message\Response', $response);
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testRefund()
+    {
+        $response = $this->gateway->refund($this->options)->send();
+
+        $this->assertInstanceOf('\Omnipay\Manual\Message\Response', $response);
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getMessage());
+    }
 }


### PR DESCRIPTION
Some projects may like to have a void() and a refund() method on manual payments so they have an ability to mark a payment as cancelled or refunded when these methods succeed.
