### PR TITLE
 Allow v3 of omnipay/common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,15 @@
         "psr-4": { "Omnipay\\Manual\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "~3.0"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "3.0.x-dev",
+            "2.x-dev": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,14 @@
         "psr-4": { "Omnipay\\Manual\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~3.0"
+        "omnipay/common": "^2.0||^3.0"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev",
-            "2.x-dev": "2.0.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
It seems that this library is so simple, that it's compatible with v2 and v3 of omnipay/common without extra modifications.