### PR TITLE
Allow omnipay/tests v3. Improve travis build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,34 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - '7.2'
+  - nightly
+
+env:
+  - COMMON_VERSION="^2.0"
+  - COMMON_VERSION="^3.0"
+
+matrix:
+  fast_finish: true
+  exclude:
+    - php: '7.2'
+      env: COMMON_VERSION="^2.0"
+    - php: nightly
+      env: COMMON_VERSION="^2.0"
+  allow_failures:
+    - php: nightly
+
+install:
+  - if [ "$COMMON_VERSION" != "" ]; then composer require "omnipay/common:$COMMON_VERSION" "omnipay/tests:$COMMON_VERSION" --no-update; fi;
+  - if [ "$COMMON_VERSION" == "^2.0" ]; then composer require "squizlabs/php_codesniffer:^1" --no-update; else composer require "squizlabs/php_codesniffer:^3" --no-update; fi;
+  - composer install -n
 
 before_script:
-  - composer install -n --dev
+  # Disable test listener in PHP 5.6, when testing against v3 of omnipay/tests because mockery's v1 listener
+  # is not compatible with PHPUnit v5.7
+  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ] && [ "$COMMON_VERSION" == "^3.0" ]; then sed -i '/<listeners>/,/<\/listeners>/d' ./phpunit.xml.dist; fi;
 
 script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "omnipay/common": "^2.0||^3.0"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "^2.0||^3.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
I didn't take into account dependency on `omnipay/tests` in my last PR.

This PR allows installation of `omnipay/tests` v3 which unblocks installation of `omnipay/common` v3 with composer.

I also updated Travis-CI build matrix, which will test the build against v2 and v3 of `omnipay/common` and `omnipay/tests`.
I added PHP 7.2 to the test matrix, which only tests v3, because v2 has some incompatible dependencies.